### PR TITLE
Add welcome screen for login/registration

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders welcome screen', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = screen.getByText(/Добро пожаловать/i);
+  expect(titleElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { lightTheme, darkTheme } from './theme';
 import MainLayout from './components/MainLayout';
 import RegistrationForm from './components/RegistrationForm';
 import LoginForm from './components/LoginForm';
+import WelcomeScreen from './components/WelcomeScreen';
 import Header from './components/Header';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
@@ -21,7 +22,8 @@ const App: React.FC = () => {
       <Router>
         <Header toggleTheme={toggleTheme} />
         <Routes>
-          <Route path="/" element={<MainLayout />} />
+          <Route path="/" element={<WelcomeScreen />} />
+          <Route path="/home" element={<MainLayout />} />
           <Route path="/register" element={<RegistrationForm />} />
           <Route path="/login" element={<LoginForm />} />
         </Routes>

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import Button from './Button';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: ${({ theme }) => theme.background};
+  color: ${({ theme }) => theme.text};
+`;
+
+const Title = styled.h1`
+  margin-bottom: 20px;
+  font-size: 2rem;
+`;
+
+const Info = styled.p`
+  margin-bottom: 40px;
+  text-align: center;
+  max-width: 600px;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  gap: 20px;
+`;
+
+const WelcomeScreen: React.FC = () => (
+  <Container>
+    <Title>Добро пожаловать в \"Сборник\"</Title>
+    <Info>
+      Это платформа для публикации и обмена знаниями. Если у вас уже есть аккаунт, войдите. Новым пользователям доступна регистрация.
+    </Info>
+    <Buttons>
+      <Link to="/login">
+        <Button>Войти</Button>
+      </Link>
+      <Link to="/register">
+        <Button>Регистрация</Button>
+      </Link>
+    </Buttons>
+  </Container>
+);
+
+export default WelcomeScreen;


### PR DESCRIPTION
## Summary
- create `WelcomeScreen` with links to log in or register
- set `/` route to new screen and move old content to `/home`
- update test to check welcome page

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684046d0ec50832fbc8c718dea65f9ad